### PR TITLE
Use latest version of unicorn 5.x vs. 4.x

### DIFF
--- a/unicorn-prewarm.gemspec
+++ b/unicorn-prewarm.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.1'
 
-  spec.add_dependency 'unicorn', '~> 4.8.0'
+  spec.add_dependency 'unicorn'
 end


### PR DESCRIPTION
Removes version requirement for `unicorn` `4.8.x` since this doesn't appear to be a functional requirement.

Allows using `unicorn-prewarm` with `unicorn` `5.x` series.